### PR TITLE
Fixes comment configuration

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "%",
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
This pull-request fixes `language-configuration.json` to fix the behaviour of vscode's functionality to toggle comments.