### PR TITLE
Enable SATySFi mode for '.satyg' files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
         ],
         "extensions": [
           ".saty",
-          ".satyh"
+          ".satyh",
+          ".satyg"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
Hello wraikny, thank you for developing this extension! It helps me a lot write SATySFi code with vs code.

This MR is just for enabling SATySFi mode for files with '.satyg' extensions. According to [SATySFi's standard library](https://github.com/gfngfn/SATySFi/tree/master/lib-satysfi/dist/packages), this file extension seems to be used for SATySFi code for non-typesetting purpose (like `list` or `option`).